### PR TITLE
Make serialization tolerant of missing protected header

### DIFF
--- a/jwe.go
+++ b/jwe.go
@@ -216,7 +216,7 @@ func parseEncryptedCompact(input string) (*JsonWebEncryption, error) {
 
 // CompactSerialize serializes an object using the compact serialization format.
 func (obj JsonWebEncryption) CompactSerialize() (string, error) {
-	if len(obj.recipients) > 1 || obj.unprotected != nil ||
+	if len(obj.recipients) != 1 || obj.unprotected != nil ||
 		obj.protected == nil || obj.recipients[0].header != nil {
 		return "", ErrNotSupported
 	}

--- a/jwe.go
+++ b/jwe.go
@@ -216,7 +216,8 @@ func parseEncryptedCompact(input string) (*JsonWebEncryption, error) {
 
 // CompactSerialize serializes an object using the compact serialization format.
 func (obj JsonWebEncryption) CompactSerialize() (string, error) {
-	if len(obj.recipients) > 1 || obj.unprotected != nil || obj.recipients[0].header != nil {
+	if len(obj.recipients) > 1 || obj.unprotected != nil ||
+		obj.protected == nil || obj.recipients[0].header != nil {
 		return "", ErrNotSupported
 	}
 
@@ -257,7 +258,9 @@ func (obj JsonWebEncryption) FullSerialize() string {
 		raw.EncryptedKey = newBuffer(obj.recipients[0].encryptedKey)
 	}
 
-	raw.Protected = newBuffer(mustSerializeJSON(obj.protected))
+	if obj.protected != nil {
+		raw.Protected = newBuffer(mustSerializeJSON(obj.protected))
+	}
 
 	return string(mustSerializeJSON(raw))
 }

--- a/jws.go
+++ b/jws.go
@@ -196,7 +196,7 @@ func parseSignedCompact(input string) (*JsonWebSignature, error) {
 
 // CompactSerialize serializes an object using the compact serialization format.
 func (obj JsonWebSignature) CompactSerialize() (string, error) {
-	if len(obj.Signatures) > 1 || obj.Signatures[0].header != nil {
+	if len(obj.Signatures) > 1 || obj.Signatures[0].header != nil || obj.Signatures[0].protected == nil {
 		return "", ErrNotSupported
 	}
 
@@ -216,19 +216,22 @@ func (obj JsonWebSignature) FullSerialize() string {
 	}
 
 	if len(obj.Signatures) == 1 {
-		serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
-		raw.Protected = newBuffer(serializedProtected)
+		if obj.Signatures[0].protected != nil {
+			serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
+			raw.Protected = newBuffer(serializedProtected)
+		}
 		raw.Header = obj.Signatures[0].header
 		raw.Signature = newBuffer(obj.Signatures[0].Signature)
 	} else {
 		raw.Signatures = make([]rawSignatureInfo, len(obj.Signatures))
 		for i, signature := range obj.Signatures {
-			serializedProtected := mustSerializeJSON(signature.protected)
-
 			raw.Signatures[i] = rawSignatureInfo{
-				Protected: newBuffer(serializedProtected),
 				Header:    signature.header,
 				Signature: newBuffer(signature.Signature),
+			}
+
+			if signature.protected != nil {
+				raw.Signatures[i].Protected = newBuffer(mustSerializeJSON(signature.protected))
 			}
 		}
 	}

--- a/jws.go
+++ b/jws.go
@@ -196,7 +196,7 @@ func parseSignedCompact(input string) (*JsonWebSignature, error) {
 
 // CompactSerialize serializes an object using the compact serialization format.
 func (obj JsonWebSignature) CompactSerialize() (string, error) {
-	if len(obj.Signatures) > 1 || obj.Signatures[0].header != nil || obj.Signatures[0].protected == nil {
+	if len(obj.Signatures) != 1 || obj.Signatures[0].header != nil || obj.Signatures[0].protected == nil {
 		return "", ErrNotSupported
 	}
 


### PR DESCRIPTION
Currently, the library panics when it is asked to serialize a JWS object with no protected header. Instead, it should just not attempt to serialize the protected header, and the JSON serializer will then omit the corresponding field.
